### PR TITLE
Report URL table

### DIFF
--- a/python/transparency-engine/samples/config/steps.json
+++ b/python/transparency-engine/samples/config/steps.json
@@ -170,7 +170,8 @@
                     "buyer",
                     "item"
                 ],
-                "entity_name_attribute": "company_name"
+                "entity_name_attribute": "company_name",
+                "base_url": "http://localhost:3000/report/"
             }
         }
     }

--- a/python/transparency-engine/transparency_engine/modules/graph/link_filtering/period_scoring.py
+++ b/python/transparency-engine/transparency_engine/modules/graph/link_filtering/period_scoring.py
@@ -399,7 +399,7 @@ def compute_all_period_overlap_score(
         activity_time=activity_time,
         activity_type=activity_type,
     )
-    
+
     scores_df = scores_df.selectExpr(
         f"{source_entity} as {schemas.SOURCE}",
         f"{target_entity} as {schemas.TARGET}",
@@ -459,9 +459,7 @@ def compute_active_period_summary_by_type(
         Spark DataFrame
             Active period summary for the given activity type. Output data schema [source, target, type, source_periods, target_periods, shared_periods]
     """
-    overlap_scores = temporal_overlap_scores.filter(
-        F.col("type") == activity_type
-    )
+    overlap_scores = temporal_overlap_scores.filter(F.col("type") == activity_type)
 
     # calculate source active periods
     source_periods = overlap_scores.filter(

--- a/python/transparency-engine/transparency_engine/pipeline/transparency_pipeline.py
+++ b/python/transparency-engine/transparency_engine/pipeline/transparency_pipeline.py
@@ -366,8 +366,9 @@ class TransparencyPipeline:
         sync_attributes = report_step.get("config", {}).get("sync_attributes", [])
         async_attributes = report_step.get("config", {}).get("async_attributes", [])
         entity_name_attribute = report_step.get("config", {}).get(
-            "entity_name_attribute", []
+            "entity_name_attribute", ""
         )
+        report_base_url = report_step.get("config", {}).get("base_url", "")
 
         # Run the report
         config = entity_report.ReportConfig(
@@ -375,6 +376,8 @@ class TransparencyPipeline:
             async_link_attributes=async_attributes,
             entity_name_attribute=entity_name_attribute,
         )
+        if report_base_url != "":
+            config.report_base_url = report_base_url
 
         report_output = entity_report.generate_report(
             entity_data=entity_data_df,
@@ -416,6 +419,7 @@ class TransparencyPipeline:
         )
         self.data_handler.write_data(report_output.entity_graph, "entity_graph_report")
         self.data_handler.write_data(report_output.html_report, "html_report")
+        self.data_handler.write_data(report_output.report_url, "report_url")
 
     def get_config(self) -> Dict[str, Any]:
         """

--- a/python/transparency-engine/transparency_engine/reporting/entity_attributes.py
+++ b/python/transparency-engine/transparency_engine/reporting/entity_attributes.py
@@ -61,7 +61,7 @@ def report_entity_attributes(
         entity_name_attribute: str
             Name of the static attribute used as the default entity name.
         default_entity_name_attribute: str, default = "default_name"
-            Name of the default entity name attribute to be added in the output d
+            Name of the default entity name attribute to be added in the output dataframe
         attribute_metadata: DataFrame, default = None
             Dataframe contaiing attribute definition, with schema [AttributeID, Name, Description].
             If None, a default metadata will be created.

--- a/python/transparency-engine/transparency_engine/reporting/report_schemas.py
+++ b/python/transparency-engine/transparency_engine/reporting/report_schemas.py
@@ -16,6 +16,9 @@ from transparency_engine.analysis.scoring.measures import NetworkMeasures
 # Default entity name attribute
 DEFAULT_ENTITY_NAME_ATTRIBUTE: Final[str] = "default_name"
 
+# default base url for the web-based report
+DEFAULT_REPORT_BASE_URL: Final[str] = "http://localhost:3000/report/"
+
 # activity link type values (to be used in PowerBI report)
 LINK_TYPE: Final[str] = "link_type"
 SYNC_ACTIVITY_LINK_TYPE: Final[str] = "sync_activity"
@@ -78,3 +81,6 @@ PATH_SOURCE_RELATIONSHIP: Final[str] = "PathSourceRelationship"
 PATH_TARGET_RELATIONSHIP: Final[str] = "PathTargetRelationship"
 PATH_SOURCE_FLAG: Final[str] = "PathSourceFlag"
 PATH_TARGET_FLAG: Final[str] = "PathTargetFlag"
+
+# column containing the URL to the web-based report page
+REPORT_LINK: Final[str] = "ReportLink"

--- a/python/transparency-engine/transparency_engine/spark/utils.py
+++ b/python/transparency-engine/transparency_engine/spark/utils.py
@@ -22,7 +22,10 @@ from pyspark.sql import SparkSession
 config = SparkConf().setAll([("spark.executor.allowSparkContext", "true")])
 
 spark: SparkSession = (
-    SparkSession.builder.appName('Transparency Engine').enableHiveSupport().config(conf=config).getOrCreate()
+    SparkSession.builder.appName("Transparency Engine")
+    .enableHiveSupport()
+    .config(conf=config)
+    .getOrCreate()
 )
 
 sc: SparkContext = spark.sparkContext

--- a/python/transparency-engine/transparency_engine/synthetic_data/public_procurement.py
+++ b/python/transparency-engine/transparency_engine/synthetic_data/public_procurement.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT license. See LICENSE file in the project.
 #
 
-from typing import Final, List, Dict
+from typing import Dict, Final, List
 
 import pyspark.sql.functions as F
 
@@ -235,7 +235,7 @@ def generate_procurement_data(
     config: DataGeneratorConfig = procurement_configs,
     n_entities: int = 1000,
     n_communities: int = 20,
-    n_periods: int = 20,  
+    n_periods: int = 20,
 ) -> Dict[str, DataFrame]:
     """
     Gerenerate synthetic data for the public procurement use case.
@@ -271,8 +271,6 @@ def generate_procurement_data(
         DYNAMIC_ATTRIBUTE_TABLE: data.dynamic_attributes,
         FLAG_TABLE: data.flags,
         FLAG_METADATA_TABLE: data.flag_metadata,
-        ATTRIBUTE_METADATA_TABLE: data.attribute_metadata
+        ATTRIBUTE_METADATA_TABLE: data.attribute_metadata,
     }
     return data_dict
-
-


### PR DESCRIPTION
This is a workaround to address the scenario where the API can't create an output table to store the report URLs due to permission issues:

- Added a **base_url** parameter to the pipeline's steps config file
- Generated the **report_url** output table from the pipeline which contains an URL to the web-based report for each entity. Each URL has the format of {base_url}/{EntityID}.